### PR TITLE
Add static files as a volume for prod deployment

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -25,6 +25,7 @@ services:
    links:
      - postgres:postgres
    volumes:
+     - static_files:/usr/src/app/OpenOversight/app/static
      - ./data:/data/
    command: scripts/entrypoint.sh
    ports:
@@ -34,8 +35,9 @@ services:
      - default
 
 volumes:
+  static_files:
+    name: openoversight-static
   postgres:
-    driver: local
 
 networks:
   protonmail:


### PR DESCRIPTION
## Description of Changes

Super quick PR - this setup is required so that nginx can serve the static files directly.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
