### PR TITLE
Fix tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ populate: create_db  ## Build and run containers
 	## Populate database with test data
 	docker-compose run --rm web python ../test_data.py -p
 
+.PHONY: testlocal
+testlocal:
+	pytest
+
 .PHONY: test
 test: start  ## Run tests
 	if [ -z "$(name)" ]; then \

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -519,6 +519,8 @@ def upload_image_to_s3_and_store_in_db(image_buf, user_id, department_id=None):
     """
     image_buf.seek(0)
     image_type = imghdr.what(image_buf)
+    if image_type not in current_app.config['ALLOWED_EXTENSIONS']:
+        raise ValueError('Attempted to pass invalid data type: {}'.format(image_type))
     image_buf.seek(0)
     pimage = Pimage.open(image_buf)
     date_taken = find_date_taken(pimage)
@@ -532,8 +534,6 @@ def upload_image_to_s3_and_store_in_db(image_buf, user_id, department_id=None):
     existing_image = Image.query.filter_by(hash_img=hash_img).first()
     if existing_image:
         return existing_image
-    if image_type not in current_app.config['ALLOWED_EXTENSIONS']:
-        raise ValueError('Attempted to pass invalid data type: {}'.format(image_type))
     try:
         new_filename = '{}.{}'.format(hash_img, image_type)
         url = upload_obj_to_s3(scrubbed_image_buf, new_filename)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,3 +12,4 @@ mypy==0.782
 sphinx==1.7.8
 sphinx-autobuild==0.7.1
 pandas>=0.23.4
+pytest-env==0.6.2

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 env =
-	FLASK_ENV=testing
-	FLASK_APP=OpenOversight/app:app
+    FLASK_ENV=testing
+    FLASK_APP=OpenOversight/app:app

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+env =
+	FLASK_ENV=testing
+	FLASK_APP=OpenOversight/app:app


### PR DESCRIPTION
## Description of Changes

Adds `pytest-env` to the dev depenendencies and some required environment variables for successfully running the tests locally. Also adds a `testlocal` entry to the Makefile.

Fixes #14 

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
