### PR TITLE
Fix featured image in officer list

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -536,7 +536,7 @@ def list_officer(department_id, page=1, race=[], gender=[], rank=[], min_age='16
     officers = officers.order_by(Officer.last_name, Officer.first_name, Officer.id)
     officers = officers.paginate(page, OFFICERS_PER_PAGE, False)
     for officer in officers.items:
-        officer_face = sorted(officer.face, key=lambda x: x.featured)
+        officer_face = sorted(officer.face, key=lambda x: x.featured, reverse=True)
 
         # could do some extra work to not lazy load images but load them all together
         # but we would want to ensure to only load the first picture of each officer


### PR DESCRIPTION
## Description of Changes

Resolves #16

It turns out, when sorting a list of booleans, python interprets them as integers. Which means that `False` is `0` and `True` is `1`. Which means that `False` values always come before `True`. Which means that, for a list where there's only ever one `True` value (as is the case with featured images), the featured image will _always be last_, and this would _never have been shown_ for officers with more than one image :)

```python
[ins] In [1]: x = [False, True, False, False]

[ins] In [2]: sorted(x)
Out[2]: [False, False, False, True]
```

This fixes that :)

In 1 line :)

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
