### PR TITLE
Fix title on find officer page

### DIFF
--- a/OpenOversight/app/templates/input_find_officer.html
+++ b/OpenOversight/app/templates/input_find_officer.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% block content %}
 {% block title %}Find an officer - OpenOversight{% endblock %}
 {% block meta %}<meta name="description" content="Find an officer you interacted with using this form.">{% endblock %}
+{% block content %}
 <div role="main">
     <div class="hero-section no-sub">
         <div class="hero">Find an Officer </div>


### PR DESCRIPTION
## Description of Changes

The find an officer page incorrectly had the title and meta blocks inside the content block. This was causing neither of them to apply correctly. To fix it we simply need to move them into the top level scope of the template, out of the content block.

Closes #20 

## Notes for Deployment

## Screenshots (if appropriate)

<img width="1524" alt="Captura de Tela 2021-07-05 às 11 34 56" src="https://user-images.githubusercontent.com/24264157/124508644-34228b00-dd85-11eb-9716-c26faa30d245.png">


## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
