### PR TITLE
Add command to copy face images

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -99,7 +99,8 @@ def create_app(config_name='default'):
     Migrate(app, db, os.path.join(os.path.dirname(__file__), '..', 'migrations'))  # Adds 'db' command
     from .commands import (make_admin_user, link_images_to_department,
                            link_officers_to_department, bulk_add_officers,
-                           add_department, add_job_title, advanced_csv_import)
+                           add_department, add_job_title, advanced_csv_import,
+                           use_original_image_for_faces)
     app.cli.add_command(make_admin_user)
     app.cli.add_command(link_images_to_department)
     app.cli.add_command(link_officers_to_department)
@@ -107,6 +108,7 @@ def create_app(config_name='default'):
     app.cli.add_command(add_department)
     app.cli.add_command(add_job_title)
     app.cli.add_command(advanced_csv_import)
+    app.cli.add_command(use_original_image_for_faces)
 
     return app
 

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -12,7 +12,7 @@ import click
 from flask import current_app
 from flask.cli import with_appcontext
 
-from .models import db, Assignment, Department, Officer, User, Salary, Job
+from .models import Face, db, Assignment, Department, Officer, User, Salary, Job
 from .utils import get_officer, str_is_true, normalize_gender, prompt_yes_no
 
 from .csv_imports import import_csv_files
@@ -553,4 +553,16 @@ def add_job_title(department_id, job_title, is_sworn_officer, order):
     job = Job(job_title=job_title, is_sworn_officer=is_sworn, order=order, department=department)
     db.session.add(job)
     print('Added {} to {}'.format(job.job_title, department.name))
+    db.session.commit()
+
+
+@click.command()
+@with_appcontext
+def use_original_image_for_faces():
+    """
+    Migrate created Faces to use the original image ID instead of the cropped one
+    """
+    faces = Face.query.all()
+    for face in faces:
+        face.img_id = face.original_image_id
     db.session.commit()


### PR DESCRIPTION
## Description of Changes

Adds a command to copy `original_image_id` to `img_id` so that we get the original images instead of the cropped ones. Use this to restore the original images.

## Notes for Deployment

Run it by running `dc run --rm web flask use-original-image-for-faces`

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
