### PR TITLE
Fix gif uploading

### DIFF
--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -526,8 +526,9 @@ def upload_image_to_s3_and_store_in_db(image_buf, user_id, department_id=None):
     date_taken = find_date_taken(pimage)
     if date_taken:
         date_taken = datetime.datetime.strptime(date_taken, '%Y:%m:%d %H:%M:%S')
+    scrub_exif(pimage)
     scrubbed_image_buf = BytesIO()
-    scrub_exif(pimage).save(scrubbed_image_buf, image_type)
+    pimage.save(scrubbed_image_buf, image_type)
     scrubbed_image_buf.seek(0)
     image_data = scrubbed_image_buf.read()
     hash_img = compute_hash(image_data)
@@ -569,11 +570,8 @@ def find_date_taken(pimage):
 
 
 # https://gist.github.com/ngtvspc/a686dda375df122ba1a5dd8e6654532b
-def scrub_exif(pimage):
-    image_data = list(pimage.getdata())
-    image_without_exif = Pimage.new(pimage.mode, pimage.size)
-    image_without_exif.putdata(image_data)
-    return image_without_exif
+def scrub_exif(pimage: Pimage.Image):
+    pimage.getexif().clear()
 
 
 def get_officer(department_id, star_no, first_name, last_name):

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -526,7 +526,7 @@ def upload_image_to_s3_and_store_in_db(image_buf, user_id, department_id=None):
     date_taken = find_date_taken(pimage)
     if date_taken:
         date_taken = datetime.datetime.strptime(date_taken, '%Y:%m:%d %H:%M:%S')
-    scrub_exif(pimage)
+    pimage.getexif().clear()
     scrubbed_image_buf = BytesIO()
     pimage.save(scrubbed_image_buf, image_type)
     scrubbed_image_buf.seek(0)
@@ -567,11 +567,6 @@ def find_date_taken(pimage):
             return exif[36867]
     else:
         return None
-
-
-# https://gist.github.com/ngtvspc/a686dda375df122ba1a5dd8e6654532b
-def scrub_exif(pimage: Pimage.Image):
-    pimage.getexif().clear()
 
 
 def get_officer(department_id, star_no, first_name, last_name):

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -559,10 +559,11 @@ def find_date_taken(pimage):
     if isinstance(pimage, PngImageFile):
         return None
 
-    if pimage._getexif():
+    exif = hasattr(pimage, '_getexif') and pimage._getexif()
+    if exif:
         # 36867 in the exif tags holds the date and the original image was taken https://www.awaresystems.be/imaging/tiff/tifftags/privateifd/exif.html
-        if 36867 in pimage._getexif():
-            return pimage._getexif()[36867]
+        if 36867 in exif:
+            return exif[36867]
     else:
         return None
 


### PR DESCRIPTION
## Description of Changes

Fixes when an image has no exif data AND also changes how we were scrubbing exif data so that it doesn't wipe out the color profile for a GIF.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
