### PR TITLE
Bugfix: close the image to free up memory

### DIFF
--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -529,6 +529,7 @@ def upload_image_to_s3_and_store_in_db(image_buf, user_id, department_id=None):
     pimage.getexif().clear()
     scrubbed_image_buf = BytesIO()
     pimage.save(scrubbed_image_buf, image_type)
+    pimage.close()
     scrubbed_image_buf.seek(0)
     image_data = scrubbed_image_buf.read()
     hash_img = compute_hash(image_data)


### PR DESCRIPTION
## Description of Changes

This PR adds a one line fix to ensure that PIL properly closes the image and releases memory. Previously, the memory was not being freed and our workers were dying on large image uploads.

**Before**:

```
Line #    Mem usage    Increment  Occurences   Line Contents
============================================================
   515     95.5 MiB     95.5 MiB           1   @memory_profile
   516                                         def upload_image_to_s3_and_store_in_db(image_buf, user_id, department_id=None):
   517                                             """
   518                                             Just a quick explaination of the order of operations here...
   519                                             we have to scrub the image before we do anything else like hash it
   520                                             but we also have to get the date for the image before we scrub it.
   521                                             """
   522     95.5 MiB      0.0 MiB           1       image_buf.seek(0)
   523     95.5 MiB      0.0 MiB           1       image_type = imghdr.what(image_buf)
   524     95.5 MiB      0.0 MiB           1       if image_type not in current_app.config['ALLOWED_EXTENSIONS']:
   525                                                 raise ValueError('Attempted to pass invalid data type: {}'.format(image_type))
   526     95.5 MiB      0.0 MiB           1       image_buf.seek(0)
   527     95.8 MiB      0.3 MiB           1       pimage = Pimage.open(image_buf)
   528     95.8 MiB      0.0 MiB           1       date_taken = find_date_taken(pimage)
   529     95.8 MiB      0.0 MiB           1       if date_taken:
   530                                                 date_taken = datetime.datetime.strptime(date_taken, '%Y:%m:%d %H:%M:%S')
   531     95.8 MiB      0.0 MiB           1       pimage.getexif().clear()
   532     95.8 MiB      0.0 MiB           1       scrubbed_image_buf = BytesIO()
   533    155.4 MiB     59.6 MiB           1       pimage.save(scrubbed_image_buf, image_type)
   534    155.4 MiB      0.0 MiB           1       scrubbed_image_buf.seek(0)
   535    156.9 MiB      1.5 MiB           1       image_data = scrubbed_image_buf.read()
   536    156.9 MiB      0.0 MiB           1       hash_img = compute_hash(image_data)
   537    157.1 MiB      0.2 MiB           1       existing_image = Image.query.filter_by(hash_img=hash_img).first()
   538    157.1 MiB      0.0 MiB           1       if existing_image:
   539                                                 return existing_image
   540    157.1 MiB      0.0 MiB           1       try:
   541    157.1 MiB      0.0 MiB           1           new_filename = '{}.{}'.format(hash_img, image_type)
   542    167.2 MiB     10.1 MiB           1           url = upload_obj_to_s3(scrubbed_image_buf, new_filename)
   543                                                 new_image = Image(filepath=url, hash_img=hash_img,
   544                                                                   date_image_inserted=datetime.datetime.now(),
   545                                                                   department_id=department_id,
   546                                                                   date_image_taken=date_taken,
   547                                                                   user_id=user_id
   548                                                                   )
   549                                                 db.session.add(new_image)
   550                                                 db.session.commit()
   551                                                 return new_image
   552    167.2 MiB      0.0 MiB           1       except ClientError:
   553    167.2 MiB      0.0 MiB           1           exception_type, value, full_tback = sys.exc_info()
   554    167.4 MiB      0.0 MiB           2           current_app.logger.error('Error uploading to S3: {}'.format(
   555    167.4 MiB      0.0 MiB           2               ' '.join([str(exception_type), str(value),
   556    167.4 MiB      0.2 MiB           1                         format_exc()])
   557                                                 ))
   558    167.4 MiB      0.0 MiB           1           return None
```

**After**:
```
Line #    Mem usage    Increment  Occurences   Line Contents
============================================================
   515     96.9 MiB     96.9 MiB           1   @memory_profile
   516                                         def upload_image_to_s3_and_store_in_db(image_buf, user_id, department_id=None):
   517                                             """
   518                                             Just a quick explaination of the order of operations here...
   519                                             we have to scrub the image before we do anything else like hash it
   520                                             but we also have to get the date for the image before we scrub it.
   521                                             """
   522     96.9 MiB      0.0 MiB           1       image_buf.seek(0)
   523     96.9 MiB      0.0 MiB           1       image_type = imghdr.what(image_buf)
   524     96.9 MiB      0.0 MiB           1       if image_type not in current_app.config['ALLOWED_EXTENSIONS']:
   525                                                 raise ValueError('Attempted to pass invalid data type: {}'.format(image_type))
   526     96.9 MiB      0.0 MiB           1       image_buf.seek(0)
   527     96.9 MiB      0.0 MiB           1       with Pimage.open(image_buf) as pimage:
   528     96.9 MiB      0.0 MiB           1           date_taken = find_date_taken(pimage)
   529     96.9 MiB      0.0 MiB           1           if date_taken:
   530                                                     date_taken = datetime.datetime.strptime(date_taken, '%Y:%m:%d %H:%M:%S')
   531     96.9 MiB      0.0 MiB           1           pimage.getexif().clear()
   532     96.9 MiB      0.0 MiB           1           scrubbed_image_buf = BytesIO()
   533    157.0 MiB     60.0 MiB           1           pimage.save(scrubbed_image_buf, image_type)
   534     99.4 MiB    -57.6 MiB           1           pimage.close()
   537     99.4 MiB      0.0 MiB           1       scrubbed_image_buf.seek(0)
   538    101.2 MiB      1.8 MiB           1       image_data = scrubbed_image_buf.read()
   539    101.2 MiB      0.0 MiB           1       hash_img = compute_hash(image_data)
   540    101.2 MiB      0.0 MiB           1       existing_image = Image.query.filter_by(hash_img=hash_img).first()
   541    101.2 MiB      0.0 MiB           1       if existing_image:
   542                                                 return existing_image
   543    101.2 MiB      0.0 MiB           1       try:
   544    101.2 MiB      0.0 MiB           1           new_filename = '{}.{}'.format(hash_img, image_type)
   545    111.5 MiB     10.3 MiB           1           url = upload_obj_to_s3(scrubbed_image_buf, new_filename)
   546    111.5 MiB      0.0 MiB           2           new_image = Image(filepath=url, hash_img=hash_img,
   547    111.5 MiB      0.0 MiB           1                             date_image_inserted=datetime.datetime.now(),
   548    111.5 MiB      0.0 MiB           1                             department_id=department_id,
   549    111.5 MiB      0.0 MiB           1                             date_image_taken=date_taken,
   550    111.5 MiB      0.0 MiB           1                             user_id=user_id
   551                                                                   )
   552    111.5 MiB      0.0 MiB           1           db.session.add(new_image)
   553    111.5 MiB      0.0 MiB           1           db.session.commit()
   554    111.5 MiB      0.0 MiB           1           return new_image
   555                                             except ClientError:
   556                                                 exception_type, value, full_tback = sys.exc_info()
   557                                                 current_app.logger.error('Error uploading to S3: {}'.format(
   558                                                     ' '.join([str(exception_type), str(value),
   559                                                               format_exc()])
   560                                                 ))
   561                                                 return None
```

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
