### PR TITLE
Munger: Twitter Links

### DIFF
--- a/OpenOversight/app/csv_imports.py
+++ b/OpenOversight/app/csv_imports.py
@@ -405,14 +405,13 @@ def import_csv_files(
 
     existing_officers = Officer.query.filter_by(department_id=department_id).all()
     id_to_officer = {officer.id: officer for officer in existing_officers}
+    all_officers = {str(k): v for k, v in id_to_officer.items()}
 
     if officers_csv is not None:
         new_officers = _handle_officers_csv(
             officers_csv, department_name, department_id, id_to_officer, force_create
         )
-
-    all_officers = {str(k): v for k, v in id_to_officer.items()}
-    all_officers.update(new_officers)
+        all_officers.update(new_officers)
 
     if assignments_csv is not None:
         _handle_assignments_csv(

--- a/data-munging/divest_spd_links.py
+++ b/data-munging/divest_spd_links.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+from pathlib import Path
+
+import click
+import pandas as pd
+
+
+def main(id_path: Path, link_path: Path, output: Path):
+    ids = pd.read_csv(id_path, usecols=["id", "badge number"])
+    links = pd.read_csv(link_path)
+    # Collapse the multiple links columns into a single column list
+    links["url"] = (
+        links[["Links", "last updated: 8/6/2021", "Unnamed: 6"]].values.tolist().head()
+    )
+    # Make the badge column a string
+    links["badge number"] = links["Badge Number"].astype(str)
+    # Subset the columns at this point
+    links = links[["badge number", "url"]]
+    # Explode the list of links into individual rows
+    links = links.explode("url", ignore_index=True)
+    # Drop any rows where a link doesn't exist (this will be most)
+    links = links[links["url"].notna()]
+    # Join the two dataframes on badge number, discard any rows with missing values
+    merged = links.merge(ids, how="inner").astype({"id": pd.Int64Dtype()})[["id", "url"]]
+    # Rename id to "officer_ids", used in importer:
+    # https://openoversight.readthedocs.io/en/latest/advanced_csv_import.html#links-csv
+    merged.columns = ["officer_ids", "url"]
+    # Add the extra column info
+    merged["title"] = "Divest SPD Twitter thread"
+    merged["link_type"] = "Link"
+    merged["author"] = "Divest SPD"
+    merged.to_csv(output, index=False)

--- a/data-munging/divest_spd_links.py
+++ b/data-munging/divest_spd_links.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python
+import logging
 from pathlib import Path
 
 import click
 import pandas as pd
 
 
+log = logging.getLogger()
+
+
 def main(id_path: Path, link_path: Path, output: Path):
+    log.info("Starting import")
     ids = pd.read_csv(id_path, usecols=["id", "badge number"])
     links = pd.read_csv(link_path)
     # Collapse the multiple links columns into a single column list
@@ -20,10 +25,13 @@ def main(id_path: Path, link_path: Path, output: Path):
     links = links.explode("url", ignore_index=True)
     # Drop any rows where a link doesn't exist (this will be most)
     links = links[links["url"].notna()]
-    # Join the two dataframes on badge number, discard any rows with missing values
-    merged = links.merge(ids, how="inner").astype({"id": pd.Int64Dtype()})[
-        ["id", "url"]
-    ]
+    # Join the two dataframes on badge number
+    merged = links.merge(ids, how="left").astype({"id": pd.Int64Dtype()})
+    # Split off the links that don't have an OpenOversight badge associated with them
+    _has_id = merged["id"].notna()
+    missing = merged[~_has_id]
+    # Remove those missing urls
+    merged = merged[_has_id][["id", "url"]]
     # Rename id to "officer_ids", used in importer:
     # https://openoversight.readthedocs.io/en/latest/advanced_csv_import.html#links-csv
     merged.columns = ["officer_ids", "url"]
@@ -37,7 +45,12 @@ def main(id_path: Path, link_path: Path, output: Path):
     merged.loc[_not_divest, "author"] = "nbd1232"
     # Add an empty id column
     merged["id"] = None
+    missing_output = output.parent / f"{output.stem}__missing.csv"
+    log.info(f"Writing {len(missing)} missing records to {missing_output}")
+    missing.to_csv(missing_output, index=False)
+    log.info(f"Writing {len(merged)} output records to {output}")
     merged.to_csv(output, index=False)
+    log.info("Finished")
 
 
 @click.command()
@@ -45,6 +58,10 @@ def main(id_path: Path, link_path: Path, output: Path):
 @click.argument("link_path", type=click.Path(exists=True, path_type=Path))
 @click.argument("output", type=click.Path(exists=True, path_type=Path))
 def cli(id_path: Path, link_path: Path, output: Path):
+    logging.basicConfig(
+        format="[%(asctime)s - %(name)s - %(lineno)3d][%(levelname)s] %(message)s",
+        level=logging.INFO,
+    )
     main(id_path, link_path, output)
 
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,24 @@
+DC := "docker-compose"
+RUN := DC + " run --rm web"
+
+
+build:
+	{{ DC }} build
+
+up service="":
+	{{ DC }} up -d {{ service }}
+
+down:
+	{{ DC }} down
+
+fresh-start:
+	# Tear down existing containers, remove volume
+	{{ DC }} down
+	docker volume rm openoversight_postgres openoversight_minio || true
+	{{ DC }} build
+
+	# Start up and populate fields
+	{{ RUN }} python ../create_db.py
+	{{ RUN }} flask make-admin-user
+	{{ RUN }} flask add-department "Seattle Police Department" "SPD"
+	{{ RUN }} flask bulk-add-officers /data/init_data.csv

--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 DC := "docker-compose"
 RUN := DC + " run --rm web"
+set dotenv-load := false
 
 
 build:
@@ -22,6 +23,9 @@ fresh-start:
 	{{ RUN }} flask make-admin-user
 	{{ RUN }} flask add-department "Seattle Police Department" "SPD"
 	{{ RUN }} flask bulk-add-officers /data/init_data.csv
+
+run +args:
+	{{ RUN }} {{ args }}
 
 import +args:
 	{{ RUN }} flask advanced-csv-import {{ args }}

--- a/justfile
+++ b/justfile
@@ -22,3 +22,6 @@ fresh-start:
 	{{ RUN }} flask make-admin-user
 	{{ RUN }} flask add-department "Seattle Police Department" "SPD"
 	{{ RUN }} flask bulk-add-officers /data/init_data.csv
+
+import +args:
+	{{ RUN }} flask advanced-csv-import {{ args }}


### PR DESCRIPTION
## Description of Changes

This PR adds a script for taking 1) the officer list from OO and 2) the list of Divest SPD threads and combining them into a links CSV that can be used with the [advanced CSV importer](https://openoversight.readthedocs.io/en/latest/advanced_csv_import.html#links-csv).

I also added a `justfile` because that helped with some of my development.

Note too that there was a bug I had to fix in the CSV handling script - it would fail unless you also provided an officer CSV. The links CSV is sufficient on its own, so I swapped some variables around to make everything defined appropriately.

## Notes for Deployment

If you'd like to test this locally reach out to me, I'll provide you the Divest SPD CSV.

The munging can be run with `python data-munging/divest_spd_links.py <OO-CSV> <Divest-SPD-CSV> <output>`.

The importer can then be run with `just import "Seattle\ Police\ Department" --links-csv /data/munged-divest-links.csv` (note the escaped spaces).

## Screenshots (if appropriate)

![Screenshot_2021-08-14_20-07-57](https://user-images.githubusercontent.com/10214785/129465909-b0a6bec2-35ad-4d3f-88c9-b5de51517c59.png)
![Screenshot_2021-08-14_20-07-42](https://user-images.githubusercontent.com/10214785/129465910-40036a3f-da7e-4105-a025-a7b78cf39152.png)


## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
