### PR TITLE
Munger: Demographics

### DIFF
--- a/data-munging/demographic_data.py
+++ b/data-munging/demographic_data.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+import logging
+from pathlib import Path
+
+import click
+import pandas as pd
+
+
+log = logging.getLogger()
+
+
+def main(id_path: Path, demographic_path: Path, output: Path):
+    log.info("Starting import")
+    ids = pd.read_csv(id_path, usecols=["id", "badge number"])
+    demo = pd.read_csv(
+        demographic_path,
+        usecols=[
+            "Officer ID",
+            "Officer Gender",
+            "Officer Race",
+            "Officer Year of Birth",
+        ],
+    )
+    # Join the two dataframes on badge number
+    demo.columns = ["badge", "gender", "race", "dob"]
+    demo = demo.drop_duplicates()
+    demo.loc[:, "gender"] = demo["gender"].astype("category")
+    demo.loc[:, "gender"] = demo["gender"].cat.rename_categories({"N": "Other"})
+    races = {
+        "White": "WHITE",
+        "Asian": "ASIAN",
+        "Black or African American": "BLACK",
+        "American Indian/Alaska Native": "NATIVE AMERICAN",
+        "Nat Hawaiian/Oth Pac Islander": "PACIFIC ISLANDER",
+        "Hispanic or Latino": "HISPANIC",
+        "Two or More Races": "Other",
+        "Not Specified": None,
+        "Unknown": None,
+    }
+    demo.loc[:, "race"] = demo["race"].replace(races)
+    demo.loc[:, "dob"] = demo["dob"].str[:4].astype(int)
+    demo.loc[:, "badge"] = demo["badge"].str.strip()
+    merged = demo.merge(
+        ids, how="left", left_on="badge", right_on="badge number"
+    ).astype({"id": pd.Int64Dtype()})
+    merged = merged[["id", "gender", "race", "dob"]]
+    # Rename columns, add required
+    # https://openoversight.readthedocs.io/en/latest/advanced_csv_import.html#officers-csv
+    merged.columns = ["id", "gender", "race", "birth_year"]
+    # Split off the links that don't have an OpenOversight badge associated with them
+    _has_id = merged["id"].notna()
+    missing = merged[~_has_id]
+    # Remove those missing urls
+    merged = merged[_has_id]
+    # Add the extra column info
+    merged["department_name"] = "Seattle Police Department"
+    missing_output = output.parent / f"{output.stem}__missing.csv"
+    log.info(f"Writing {len(missing)} missing records to {missing_output}")
+    missing.to_csv(missing_output, index=False)
+    log.info(f"Writing {len(merged)} output records to {output}")
+    merged.to_csv(output, index=False)
+    log.info("Finished")
+
+
+@click.command()
+@click.argument("id_path", type=click.Path(exists=True, path_type=Path))
+@click.argument("demographic_path", type=click.Path(exists=True, path_type=Path))
+@click.argument("output", type=click.Path(path_type=Path))
+def cli(id_path: Path, demographic_path: Path, output: Path):
+    logging.basicConfig(
+        format="[%(asctime)s - %(name)s - %(lineno)3d][%(levelname)s] %(message)s",
+        level=logging.INFO,
+    )
+    main(id_path, demographic_path, output)
+
+
+if __name__ == "__main__":
+    cli()

--- a/data-munging/demographic_data.py
+++ b/data-munging/demographic_data.py
@@ -51,14 +51,14 @@ def main(id_path: Path, demographic_path: Path, output: Path):
     merged = demo.merge(
         ids, how="left", left_on="badge", right_on="badge number"
     ).astype({"id": pd.Int64Dtype()})
+    # Split off the links that don't have an OpenOversight badge associated with them
+    _has_id = merged["id"].notna()
+    missing = merged[~_has_id]
     # Reduce to only the necessary columns
     merged = merged[["id", "gender", "race", "dob"]]
     # Rename columns, add required
     # https://openoversight.readthedocs.io/en/latest/advanced_csv_import.html#officers-csv
     merged.columns = ["id", "gender", "race", "birth_year"]
-    # Split off the links that don't have an OpenOversight badge associated with them
-    _has_id = merged["id"].notna()
-    missing = merged[~_has_id]
     # Remove those missing urls
     merged = merged[_has_id]
     # Add the extra column info


### PR DESCRIPTION
## Description of Changes

This PR adds a script for taking the officer list from OO and the demographic data available from the [Seattle City Crisis Dataset](https://data.seattle.gov/Public-Safety/Crisis-Data/i2q9-thny). This one is very similar to #39, and if this trend continues I might generalize some of the machinery that combines the data with the OO records.

## Notes for Deployment

You can download the Crisis Data CSV using the link above.

The munging can be run with `python data-munging/demographic_data.py <OO-CSV> <Crisis-Data-CSV> <output>`.

The importer can then be run with `just import --officers-csv /data/demographic-data.csv "Seattle\ Police\ Department"`

## Screenshots (if appropriate)

![Screenshot_2021-08-24_18-02-07](https://user-images.githubusercontent.com/10214785/130710081-9d8427ab-3551-4e16-849b-6a4f31cf7a1b.png)


## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
